### PR TITLE
Add event template buttons

### DIFF
--- a/src/api/calendar.ts
+++ b/src/api/calendar.ts
@@ -7,6 +7,7 @@ interface CreateEventParams {
   start: string;   // イベントの開始日時。ISO 8601形式 (例: YYYY-MM-DDTHH:MM:SS+HH:MM)。タイムゾーン情報を含むことが重要です。
   end: string;     // イベントの終了日時。ISO 8601形式。
   location?: string; // イベントの場所。オプション。
+  description?: string; // イベントの説明。オプション。
 }
 
 // Googleカレンダーにイベントを作成するための非同期関数。
@@ -29,6 +30,7 @@ export async function createCalendarEvent(params: CreateEventParams) {
     start: params.start,
     end: params.end,
     location: params.location,
+    description: params.description,
   });
 
   // Make Webhookからの生のレスポンスデータをコンソールに出力します。


### PR DESCRIPTION
## Summary
- allow filling the add-event form from predefined templates
- support optional event description
- send description to Make webhook API

## Testing
- `npm run lint`
- `NEXT_FONT_GOOGLE_DOWNLOAD=never npm run build` *(fails: Failed to fetch font file)*

------
https://chatgpt.com/codex/tasks/task_e_687b3e4a227883209c1a842216338355